### PR TITLE
Derive all other derivable traits

### DIFF
--- a/src/cidr/ip_cidr.rs
+++ b/src/cidr/ip_cidr.rs
@@ -8,7 +8,7 @@ use crate::cidr::ipv6_cidr::{Ipv6Cidr, Ipv6CidrIpv6AddrIterator};
 
 // TODO: IpCidr
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone, Hash)]
 // The type which can be taken as an IP address.
 pub enum IpCidr {
     V4(Ipv4Cidr),
@@ -91,7 +91,7 @@ impl FromStr for IpCidr {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash)]
 /// Possible errors of `IpCidr`.
 pub enum IpCidrError {
     IncorrectBitsRange,
@@ -178,14 +178,14 @@ impl IpCidr {
 }
 
 // TODO: IpCidrIpAddrIterator
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash)]
 enum IpCidrIpsAddrIterator {
     V4(Ipv4CidrIpv4AddrIterator),
     V6(Ipv6CidrIpv6AddrIterator),
 }
 
 /// To iterate IP CIDRs.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash)]
 pub struct IpCidrIpAddrIterator {
     iter: IpCidrIpsAddrIterator,
 }

--- a/src/cidr/ipv4_cidr.rs
+++ b/src/cidr/ipv4_cidr.rs
@@ -113,7 +113,7 @@ impl<T: Ipv4Able> Ipv4Able for &T {
 // TODO: Ipv4Cidr
 
 /// To represent IPv4 CIDR.
-#[derive(PartialEq, Eq, Clone)]
+#[derive(PartialEq, Eq, Copy, Clone, Hash)]
 pub struct Ipv4Cidr {
     prefix: u32,
     mask: u32,
@@ -218,7 +218,7 @@ impl Ipv4Cidr {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash)]
 /// Possible errors of `Ipv4Cidr`.
 pub enum Ipv4CidrError {
     IncorrectBitsRange,
@@ -397,7 +397,7 @@ impl Ipv4Cidr {
 // TODO: Ipv4CidrU8ArrayIterator
 
 /// To iterate IPv4 CIDRs.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash)]
 pub struct Ipv4CidrU8ArrayIterator {
     rev_from: u32,
     next: u64,
@@ -464,7 +464,7 @@ impl Ipv4Cidr {
 // TODO: Ipv4CidrIterator
 
 /// To iterate IPv4 CIDRs.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash)]
 pub struct Ipv4CidrIterator {
     iter: Ipv4CidrU8ArrayIterator,
 }
@@ -509,7 +509,7 @@ impl Ipv4Cidr {
 // TODO: Ipv4CidrIpv4AddrIterator
 
 /// To iterate IPv4 CIDRs.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash)]
 pub struct Ipv4CidrIpv4AddrIterator {
     iter: Ipv4CidrU8ArrayIterator,
 }

--- a/src/cidr/ipv6_cidr.rs
+++ b/src/cidr/ipv6_cidr.rs
@@ -161,7 +161,7 @@ impl<T: Ipv6Able> Ipv6Able for &T {
 // TODO: Ipv6Cidr
 
 /// To represent IPv6 CIDR.
-#[derive(PartialEq, Eq, Clone)]
+#[derive(PartialEq, Eq, Copy, Clone, Hash)]
 pub struct Ipv6Cidr {
     prefix: u128,
     mask: u128,
@@ -284,7 +284,7 @@ impl Ipv6Cidr {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash)]
 /// Possible errors of `Ipv6Cidr`.
 pub enum Ipv6CidrError {
     IncorrectBitsRange,
@@ -423,7 +423,7 @@ impl Ipv6Cidr {
 // TODO: Ipv6CidrU8ArrayIterator
 
 /// To iterate IPv6 CIDRs.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash)]
 pub struct Ipv6CidrU8ArrayIterator {
     rev_from: u128,
     next: (u128, bool),
@@ -514,7 +514,7 @@ impl Ipv6Cidr {
 // TODO: Ipv6CidrU8ArrayIterator
 
 /// To iterate IPv6 CIDRs.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash)]
 pub struct Ipv6CidrU16ArrayIterator {
     rev_from: u128,
     next: (u128, bool),
@@ -601,7 +601,7 @@ impl Ipv6Cidr {
 // TODO: Ipv6CidrIterator
 
 /// To iterate IPv6 CIDRs.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash)]
 pub struct Ipv6CidrIterator {
     iter: Ipv6CidrU8ArrayIterator,
 }
@@ -646,7 +646,7 @@ impl Ipv6Cidr {
 // TODO: Ipv6CidrIpv6AddrIterator
 
 /// To iterate IPv4 CIDRs.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash)]
 pub struct Ipv6CidrIpv6AddrIterator {
     iter: Ipv6CidrU16ArrayIterator,
 }


### PR DESCRIPTION
In my use-case I need to stuff these into `BTreeMap<>`s, and that was foiled by no `Hash` impls.

This PR gratuitously implements all traits for all structs in `cidr`.