### PR TITLE
Use std addr types for formatting.

### DIFF
--- a/src/cidr/v4/ipv4_cidr.rs
+++ b/src/cidr/v4/ipv4_cidr.rs
@@ -230,24 +230,21 @@ impl Ipv4Cidr {
 impl Debug for Ipv4Cidr {
     #[inline]
     fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
-        let prefix = self.get_prefix_as_u8_array();
-        let mask = self.get_mask_as_u8_array();
+        let prefix = self.get_prefix_as_ipv4_addr();
+        let mask = self.get_mask_as_ipv4_addr();
         let bits = self.get_bits();
 
-        debug_helper::impl_debug_for_struct!(Ipv4Cidr, f, self, (.prefix, "{}.{}.{}.{}", prefix[0], prefix[1], prefix[2], prefix[3]), (.mask, "{}.{}.{}.{}", mask[0], mask[1], mask[2], mask[3]), let .bits = bits);
+        debug_helper::impl_debug_for_struct!(Ipv6Cidr, f, self, let .prefix = prefix, let .mask = mask, let .bits = bits);
     }
 }
 
 impl Display for Ipv4Cidr {
     #[inline]
     fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
-        let prefix = self.get_prefix_as_u8_array();
+        let prefix = self.get_prefix_as_ipv4_addr();
         let bits = self.get_bits();
 
-        f.write_fmt(format_args!(
-            "{}.{}.{}.{}/{}",
-            prefix[0], prefix[1], prefix[2], prefix[3], bits
-        ))
+        f.write_fmt(format_args!("{prefix}/{bits}"))
     }
 }
 

--- a/src/cidr/v6/ipv6_cidr.rs
+++ b/src/cidr/v6/ipv6_cidr.rs
@@ -214,32 +214,21 @@ impl Ipv6Cidr {
 impl Debug for Ipv6Cidr {
     #[inline]
     fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
-        let prefix = self.get_prefix_as_u16_array();
-        let mask = self.get_mask_as_u16_array();
+        let prefix = self.get_prefix_as_ipv6_addr();
+        let mask = self.get_mask_as_ipv6_addr();
         let bits = self.get_bits();
 
-        debug_helper::impl_debug_for_struct!(Ipv6Cidr, f, self, (.prefix, "{:X}:{:X}:{:X}:{:X}:{:X}:{:X}:{:X}:{:X}", prefix[0], prefix[1], prefix[2], prefix[3], prefix[4], prefix[5], prefix[6], prefix[7]), (.mask, "{:X}:{:X}:{:X}:{:X}:{:X}:{:X}:{:X}:{:X}", mask[0], mask[1], mask[2], mask[3], mask[4], mask[5], mask[6], mask[7]), let .bits = bits);
+        debug_helper::impl_debug_for_struct!(Ipv6Cidr, f, self, let .prefix = prefix, let .mask = mask, let .bits = bits);
     }
 }
 
 impl Display for Ipv6Cidr {
     #[inline]
     fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
-        let prefix = self.get_prefix_as_u16_array();
+        let prefix = self.get_prefix_as_ipv6_addr();
         let bits = self.get_bits();
 
-        f.write_fmt(format_args!(
-            "{:X}:{:X}:{:X}:{:X}:{:X}:{:X}:{:X}:{:X}/{}",
-            prefix[0],
-            prefix[1],
-            prefix[2],
-            prefix[3],
-            prefix[4],
-            prefix[5],
-            prefix[6],
-            prefix[7],
-            bits
-        ))
+        f.write_fmt(format_args!("{prefix}/{bits}"))
     }
 }
 

--- a/tests/ipv6_cidr_combiner.rs
+++ b/tests/ipv6_cidr_combiner.rs
@@ -10,7 +10,7 @@ fn simple_test() {
     combiner.push(Ipv6Cidr::from_str("::ffff:192.168.1.103").unwrap());
 
     assert_eq!(1, combiner.len());
-    assert_eq!(Ipv6Cidr::from_str("::ffff:192.168.1.100/126").unwrap(), combiner[0]);
+    assert_eq!("::ffff:192.168.1.100/126", combiner[0].to_string());
 }
 
 #[test]
@@ -22,5 +22,5 @@ fn should_combine_same_ip() {
     combiner.push(Ipv6Cidr::from_str("::ffff:192.168.1.100").unwrap());
 
     assert_eq!(1, combiner.len());
-    assert_eq!(Ipv6Cidr::from_str("::ffff:192.168.1.100/128").unwrap(), combiner[0]);
+    assert_eq!("::ffff:192.168.1.100/128", combiner[0].to_string());
 }


### PR DESCRIPTION
This makes the displaying of cidr types consistent with the way the STD display addresses. Specifically, IPv6 addresses will now use lower-case hex characters, like STD does.