### PR TITLE
Fix clippy lints and replace for for loops with iters.

### DIFF
--- a/src/utils/ip_cidr_combiner.rs
+++ b/src/utils/ip_cidr_combiner.rs
@@ -83,23 +83,9 @@ impl IpCidrCombiner {
     /// Check an IP whether it is in these CIDRs.
     pub fn contains(&self, ip: IpAddr) -> bool {
         match ip {
-            IpAddr::V4(ipv4) => {
-                for cidr in self.ipv4.iter() {
-                    if cidr.contains(&ipv4) {
-                        return true;
-                    }
-                }
-            }
-            IpAddr::V6(ipv6) => {
-                for cidr in self.ipv6.iter() {
-                    if cidr.contains(&ipv6) {
-                        return true;
-                    }
-                }
-            }
+            IpAddr::V4(ipv4) => self.ipv4.iter().any(|cidr| cidr.contains(ipv4)),
+            IpAddr::V6(ipv6) => self.ipv6.iter().any(|cidr| cidr.contains(ipv6)),
         }
-
-        false
     }
 
     #[inline]

--- a/src/utils/v4/ipv4_cidr_combiner.rs
+++ b/src/utils/v4/ipv4_cidr_combiner.rs
@@ -52,7 +52,7 @@ impl Ipv4CidrCombiner {
                 } else {
                     let previous_cidr = self.cidr_array.get(index - 1).unwrap();
 
-                    !previous_cidr.contains(&cidr.first())
+                    !previous_cidr.contains(cidr.first())
                 };
 
                 if pushable {
@@ -138,24 +138,12 @@ impl Ipv4CidrCombiner {
     #[inline]
     /// Check an IPv4 whether it is in these CIDRs.
     pub fn contains<IP: Ipv4Able>(&self, ipv4: IP) -> bool {
-        for cidr in self.cidr_array.iter() {
-            if cidr.contains(&ipv4) {
-                return true;
-            }
-        }
-
-        false
+        self.cidr_array.iter().any(|cidr| cidr.contains(&ipv4))
     }
 
     #[inline]
     pub fn size(&self) -> u64 {
-        let mut sum = 0;
-
-        for cidr in self.cidr_array.iter() {
-            sum += cidr.size();
-        }
-
-        sum
+        self.cidr_array.iter().map(|cidr| cidr.size()).sum()
     }
 }
 

--- a/src/utils/v6/ipv6_cidr_combiner.rs
+++ b/src/utils/v6/ipv6_cidr_combiner.rs
@@ -4,8 +4,6 @@ use std::ops::Deref;
 use crate::cidr::{Ipv6Able, Ipv6Cidr};
 use crate::num_bigint::BigUint;
 
-use num_traits::Zero;
-
 /// To combine multiple IPv6 CIDRs to supernetworks.
 #[derive(Debug)]
 pub struct Ipv6CidrCombiner {
@@ -55,7 +53,7 @@ impl Ipv6CidrCombiner {
                 } else {
                     let previous_cidr = self.cidr_array.get(index - 1).unwrap();
 
-                    !previous_cidr.contains(&cidr.first())
+                    !previous_cidr.contains(cidr.first())
                 };
 
                 if pushable {
@@ -141,26 +139,12 @@ impl Ipv6CidrCombiner {
     #[inline]
     /// Check an IPv6 whether it is in these CIDRs.
     pub fn contains<IP: Ipv6Able>(&self, ipv6: IP) -> bool {
-        for cidr in self.cidr_array.iter() {
-            if cidr.contains(&ipv6) {
-                return true;
-            }
-        }
-
-        false
+        self.cidr_array.iter().any(|cidr| cidr.contains(&ipv6))
     }
 
     #[inline]
     pub fn size(&self) -> BigUint {
-        let mut sum = BigUint::zero();
-
-        for cidr in self.cidr_array.iter() {
-            let size = cidr.size();
-
-            sum += size;
-        }
-
-        sum
+        self.cidr_array.iter().map(|cidr| cidr.size()).sum()
     }
 }
 


### PR DESCRIPTION
CI was failing in #10 for reasons unrelated to my changes. This is caused by, I guess, new-ish clippy lints.
This PR fixes those lints and also, as a drive-by, refactors a few for loops into slightly more idiomatic usage of iterators.