### PR TITLE
improve docs

### DIFF
--- a/src/cidr/ip_cidr.rs
+++ b/src/cidr/ip_cidr.rs
@@ -105,7 +105,7 @@ impl IpCidr {
 
 impl Display for IpCidr {
     #[inline]
-    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
             IpCidr::V4(cidr) => Display::fmt(&cidr, f),
             IpCidr::V6(cidr) => Display::fmt(&cidr, f),

--- a/src/cidr/ip_cidr_iterators.rs
+++ b/src/cidr/ip_cidr_iterators.rs
@@ -62,6 +62,7 @@ impl DoubleEndedIterator for IpCidrIpAddrIterator {
 }
 
 impl IpCidr {
+    /// Returns iterator over the IP addresses in this CIDR range.
     #[inline]
     pub fn iter_as_ip_addr(&self) -> IpCidrIpAddrIterator {
         match self {
@@ -74,6 +75,7 @@ impl IpCidr {
         }
     }
 
+    /// Returns iterator over the IP addresses in this CIDR range.
     #[inline]
     pub fn iter(&self) -> IpCidrIpAddrIterator {
         self.iter_as_ip_addr()

--- a/src/cidr/v4/ipv4_able.rs
+++ b/src/cidr/v4/ipv4_able.rs
@@ -1,6 +1,7 @@
 use std::net::Ipv4Addr;
 
 /// The type which can be taken as an IPv4 address.
+///
 /// *An `u32` value represents an IPv4 byte array (`[u8; 4]`) in big-endian (BE) order.*
 pub trait Ipv4Able {
     fn get_u32(&self) -> u32;

--- a/src/cidr/v4/ipv4_cidr.rs
+++ b/src/cidr/v4/ipv4_cidr.rs
@@ -27,8 +27,8 @@ pub struct Ipv4Cidr {
 }
 
 impl Ipv4Cidr {
+    /// Returns an integer which represents the prefix an IPv4 byte array of this CIDR in big-endian (BE) order.
     #[inline]
-    /// Get an integer which represents the prefix an IPv4 byte array of this CIDR in big-endian (BE) order.
     pub fn get_prefix(&self) -> u32 {
         self.prefix
     }
@@ -40,9 +40,7 @@ impl Ipv4Cidr {
 
     #[inline]
     pub fn get_prefix_as_ipv4_addr(&self) -> Ipv4Addr {
-        let a = self.get_prefix_as_u8_array();
-
-        Ipv4Addr::new(a[0], a[1], a[2], a[3])
+        Ipv4Addr::from(self.get_prefix_as_u8_array())
     }
 
     #[inline]
@@ -50,8 +48,8 @@ impl Ipv4Cidr {
         mask_to_bits(self.mask).unwrap()
     }
 
+    /// Returns an integer which represents the mask an IPv4 byte array of this CIDR in big-endian (BE) order.
     #[inline]
-    /// Get an integer which represents the mask an IPv4 byte array of this CIDR in big-endian (BE) order.
     pub fn get_mask(&self) -> u32 {
         get_mask(self.get_bits())
     }
@@ -63,9 +61,7 @@ impl Ipv4Cidr {
 
     #[inline]
     pub fn get_mask_as_ipv4_addr(&self) -> Ipv4Addr {
-        let a = self.get_mask_as_u8_array();
-
-        Ipv4Addr::new(a[0], a[1], a[2], a[3])
+        Ipv4Addr::from(self.get_mask_as_u8_array())
     }
 }
 
@@ -177,40 +173,55 @@ impl Ipv4Cidr {
 }
 
 impl Ipv4Cidr {
+    /// Returns the first IPv4 address in this CIDR range as a big-endian (BE) integer.
     #[inline]
-    /// Get an integer which represents the first IPv4 byte array of this CIDR in big-endian (BE) order.
     pub fn first(&self) -> u32 {
         self.get_prefix()
     }
 
+    /// Returns the first IPv4 address in this CIDR range as a big-endian byte-array.
     #[inline]
     pub fn first_as_u8_array(&self) -> [u8; 4] {
         self.get_prefix_as_u8_array()
     }
 
+    /// Returns the first IPv4 address in this CIDR range.
     #[inline]
     pub fn first_as_ipv4_addr(&self) -> Ipv4Addr {
         self.get_prefix_as_ipv4_addr()
     }
 
+    /// Returns the last IPv4 address in this CIDR range as a big-endian (BE) integer.
     #[inline]
-    /// Get an integer which represents the last IPv4 byte array of this CIDR in big-endian (BE) order.
     pub fn last(&self) -> u32 {
         !self.get_mask() | self.get_prefix()
     }
 
+    /// Returns the last IPv4 address in this CIDR range as a big-endian byte-array.
     #[inline]
     pub fn last_as_u8_array(&self) -> [u8; 4] {
         self.last().to_be_bytes()
     }
 
+    /// Returns the last IPv4 address in this CIDR range.
     #[inline]
     pub fn last_as_ipv4_addr(&self) -> Ipv4Addr {
-        let a = self.last_as_u8_array();
-
-        Ipv4Addr::new(a[0], a[1], a[2], a[3])
+        Ipv4Addr::from(self.last_as_u8_array())
     }
 
+    /// Returns number of IPs in this CIDR range.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::net::IpAddr;
+    /// # use cidr_utils::{num_bigint::BigUint, cidr::Ipv4Cidr};
+    /// let cidr = "192.168.1.0/24".parse::<Ipv4Cidr>().unwrap();
+    /// assert_eq!(cidr.size(), 256);
+    ///
+    /// let cidr = "0.0.0.0/0".parse::<Ipv4Cidr>().unwrap();
+    /// assert_eq!(cidr.size(), 2u64.pow(32));
+    /// ```
     #[inline]
     pub fn size(&self) -> u64 {
         2u64.pow(u32::from(32 - self.get_bits()))

--- a/src/cidr/v4/ipv4_cidr.rs
+++ b/src/cidr/v4/ipv4_cidr.rs
@@ -228,7 +228,7 @@ impl Ipv4Cidr {
 
 impl Debug for Ipv4Cidr {
     #[inline]
-    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
         let prefix = self.get_prefix_as_ipv4_addr();
         let mask = self.get_mask_as_ipv4_addr();
         let bits = self.get_bits();
@@ -239,7 +239,7 @@ impl Debug for Ipv4Cidr {
 
 impl Display for Ipv4Cidr {
     #[inline]
-    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
         let prefix = self.get_prefix_as_ipv4_addr();
         let bits = self.get_bits();
 
@@ -312,7 +312,7 @@ impl<'de> Deserialize<'de> for Ipv4Cidr {
             type Value = Ipv4Cidr;
 
             #[inline]
-            fn expecting(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+            fn expecting(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
                 f.write_str("an IPv4 CIDR string")
             }
 

--- a/src/cidr/v4/ipv4_cidr_iterators.rs
+++ b/src/cidr/v4/ipv4_cidr_iterators.rs
@@ -2,8 +2,6 @@ use std::net::Ipv4Addr;
 
 use super::Ipv4Cidr;
 
-// TODO: Ipv4CidrU8ArrayIterator
-
 /// To iterate IPv4 CIDRs.
 #[derive(Debug)]
 pub struct Ipv4CidrU8ArrayIterator {
@@ -217,7 +215,7 @@ pub struct Ipv4CidrIpv4AddrIterator {
 impl Ipv4CidrIpv4AddrIterator {
     #[inline]
     pub fn nth_u64(&mut self, n: u64) -> Option<Ipv4Addr> {
-        self.iter.nth_u64(n).map(|a| Ipv4Addr::new(a[0], a[1], a[2], a[3]))
+        self.iter.nth_u64(n).map(Ipv4Addr::from)
     }
 }
 
@@ -226,29 +224,29 @@ impl Iterator for Ipv4CidrIpv4AddrIterator {
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next().map(|a| Ipv4Addr::new(a[0], a[1], a[2], a[3]))
+        self.iter.next().map(Ipv4Addr::from)
     }
 
     #[inline]
     fn last(self) -> Option<Self::Item> {
-        self.iter.last().map(|a| Ipv4Addr::new(a[0], a[1], a[2], a[3]))
+        self.iter.last().map(Ipv4Addr::from)
     }
 
     #[inline]
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        self.iter.nth(n).map(|a| Ipv4Addr::new(a[0], a[1], a[2], a[3]))
+        self.iter.nth(n).map(Ipv4Addr::from)
     }
 }
 
 impl DoubleEndedIterator for Ipv4CidrIpv4AddrIterator {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.next_back().map(|a| Ipv4Addr::new(a[0], a[1], a[2], a[3]))
+        self.iter.next_back().map(Ipv4Addr::from)
     }
 
     #[inline]
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        self.iter.nth_back(n).map(|a| Ipv4Addr::new(a[0], a[1], a[2], a[3]))
+        self.iter.nth_back(n).map(Ipv4Addr::from)
     }
 }
 

--- a/src/cidr/v6/ipv6_able.rs
+++ b/src/cidr/v6/ipv6_able.rs
@@ -3,6 +3,7 @@ use std::net::Ipv6Addr;
 use super::functions::*;
 
 /// The type which can be taken as an IPv6 address.
+///
 /// *An `u128` value represents an IPv6 byte array (`[u8; 16]`) in big-endian (BE) order.*
 pub trait Ipv6Able {
     fn get_u128(&self) -> u128;

--- a/src/cidr/v6/ipv6_cidr.rs
+++ b/src/cidr/v6/ipv6_cidr.rs
@@ -46,9 +46,7 @@ impl Ipv6Cidr {
 
     #[inline]
     pub fn get_prefix_as_ipv6_addr(&self) -> Ipv6Addr {
-        let a = self.get_prefix_as_u16_array();
-
-        Ipv6Addr::new(a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7])
+        Ipv6Addr::from(self.get_prefix_as_u8_array())
     }
 
     #[inline]
@@ -74,9 +72,7 @@ impl Ipv6Cidr {
 
     #[inline]
     pub fn get_mask_as_ipv6_addr(&self) -> Ipv6Addr {
-        let a = self.get_mask_as_u16_array();
-
-        Ipv6Addr::new(a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7])
+        Ipv6Addr::from(self.get_mask_as_u8_array())
     }
 }
 
@@ -145,50 +141,68 @@ impl Ipv6Cidr {
 }
 
 impl Ipv6Cidr {
+    /// Returns the first IPv6 address in this CIDR range as a big-endian (BE) integer.
     #[inline]
-    /// Get an integer which represents the first IPv6 byte array of this CIDR in big-endian (BE) order.
     pub fn first(&self) -> u128 {
         self.get_prefix()
     }
 
+    /// Returns the first IPv6 address in this CIDR range as a big-endian byte-array.
     #[inline]
     pub fn first_as_u8_array(&self) -> [u8; 16] {
         self.get_prefix_as_u8_array()
     }
 
+    /// Returns the first IPv6 address in this CIDR range as a big-endian array of `u16`s.
     #[inline]
     pub fn first_as_u16_array(&self) -> [u16; 8] {
         self.get_prefix_as_u16_array()
     }
 
+    /// Returns the first IPv6 address in this CIDR range.
     #[inline]
     pub fn first_as_ipv6_addr(&self) -> Ipv6Addr {
         self.get_prefix_as_ipv6_addr()
     }
 
+    /// Returns the last IPv6 address in this CIDR range as a big-endian (BE) integer.
     #[inline]
-    /// Get an integer which represents the last IPv6 byte array of this CIDR in big-endian (BE) order.
     pub fn last(&self) -> u128 {
         !self.get_mask() | self.get_prefix()
     }
 
+    /// Returns the last IPv6 address in this CIDR range as a big-endian byte-array.
     #[inline]
     pub fn last_as_u8_array(&self) -> [u8; 16] {
         self.last().to_be_bytes()
     }
 
+    /// Returns the last IPv6 address in this CIDR range as a big-endian array of `u16`s.
     #[inline]
     pub fn last_as_u16_array(&self) -> [u16; 8] {
         u128_to_u16_array(self.last())
     }
 
+    /// Returns the last IPv6 address in this CIDR range.
     #[inline]
     pub fn last_as_ipv6_addr(&self) -> Ipv6Addr {
-        let a = self.last_as_u16_array();
-
-        Ipv6Addr::new(a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7])
+        Ipv6Addr::from(self.last_as_u8_array())
     }
 
+    /// Returns number of IPs in this CIDR range.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::net::IpAddr;
+    /// # use cidr_utils::{num_bigint::BigUint, cidr::Ipv6Cidr};
+    /// let cidr = "2001:4f8:3:ba::/64".parse::<Ipv6Cidr>().unwrap();
+    /// assert_eq!(cidr.size(), BigUint::from(2u8).pow(64));
+    ///
+    /// let cidr =
+    ///     "2001:4f8:3:ba:2e0:81ff:fe22:d1f1/128".parse::<Ipv6Cidr>().unwrap();
+    /// assert_eq!(cidr.size(), BigUint::from(1u64));
+    /// ```
     #[inline]
     pub fn size(&self) -> BigUint {
         BigUint::from(2u8).pow(u32::from(128 - self.get_bits()))

--- a/src/cidr/v6/ipv6_cidr.rs
+++ b/src/cidr/v6/ipv6_cidr.rs
@@ -206,7 +206,7 @@ impl Ipv6Cidr {
 
 impl Debug for Ipv6Cidr {
     #[inline]
-    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
         let prefix = self.get_prefix_as_ipv6_addr();
         let mask = self.get_mask_as_ipv6_addr();
         let bits = self.get_bits();
@@ -217,7 +217,7 @@ impl Debug for Ipv6Cidr {
 
 impl Display for Ipv6Cidr {
     #[inline]
-    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
         let prefix = self.get_prefix_as_ipv6_addr();
         let bits = self.get_bits();
 
@@ -290,7 +290,7 @@ impl<'de> Deserialize<'de> for Ipv6Cidr {
             type Value = Ipv6Cidr;
 
             #[inline]
-            fn expecting(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+            fn expecting(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
                 f.write_str("an IPv6 CIDR string")
             }
 

--- a/src/cidr/v6/ipv6_cidr_iterators.rs
+++ b/src/cidr/v6/ipv6_cidr_iterators.rs
@@ -305,8 +305,6 @@ impl Ipv6Cidr {
     }
 }
 
-// TODO: Ipv6CidrIpv6AddrIterator
-
 /// To iterate IPv4 CIDRs.
 #[derive(Debug)]
 pub struct Ipv6CidrIpv6AddrIterator {
@@ -316,16 +314,12 @@ pub struct Ipv6CidrIpv6AddrIterator {
 impl Ipv6CidrIpv6AddrIterator {
     #[inline]
     pub fn nth_big_int(&mut self, n: BigUint) -> Option<Ipv6Addr> {
-        self.iter
-            .nth_big_uint(n)
-            .map(|a| Ipv6Addr::new(a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7]))
+        self.iter.nth_big_uint(n).map(Ipv6Addr::from)
     }
 
     #[inline]
     pub fn nth_back_big_int(&mut self, n: BigUint) -> Option<Ipv6Addr> {
-        self.iter
-            .nth_back_big_uint(n)
-            .map(|a| Ipv6Addr::new(a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7]))
+        self.iter.nth_back_big_uint(n).map(Ipv6Addr::from)
     }
 }
 
@@ -334,29 +328,29 @@ impl Iterator for Ipv6CidrIpv6AddrIterator {
 
     #[inline]
     fn next(&mut self) -> Option<Ipv6Addr> {
-        self.iter.next().map(|a| Ipv6Addr::new(a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7]))
+        self.iter.next().map(Ipv6Addr::from)
     }
 
     #[inline]
     fn last(self) -> Option<Ipv6Addr> {
-        self.iter.last().map(|a| Ipv6Addr::new(a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7]))
+        self.iter.last().map(Ipv6Addr::from)
     }
 
     #[inline]
     fn nth(&mut self, n: usize) -> Option<Ipv6Addr> {
-        self.iter.nth(n).map(|a| Ipv6Addr::new(a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7]))
+        self.iter.nth(n).map(Ipv6Addr::from)
     }
 }
 
 impl DoubleEndedIterator for Ipv6CidrIpv6AddrIterator {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.next_back().map(|a| Ipv6Addr::new(a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7]))
+        self.iter.next_back().map(Ipv6Addr::from)
     }
 
     #[inline]
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        self.iter.nth_back(n).map(|a| Ipv6Addr::new(a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7]))
+        self.iter.nth_back(n).map(Ipv6Addr::from)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,7 +163,11 @@ features = ["serde"]
 ```
 */
 
-pub extern crate num_bigint;
+#![deny(rust_2018_idioms, nonstandard_style)]
+#![warn(future_incompatible)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
+pub use num_bigint;
 
 /// This module provides data structures for IPv4 CIDRs and IPv6 CIDRs.
 pub mod cidr;

--- a/src/utils/ip_cidr_combiner.rs
+++ b/src/utils/ip_cidr_combiner.rs
@@ -118,7 +118,7 @@ impl IpCidrCombiner {
 
 impl Display for IpCidrCombiner {
     #[inline]
-    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
         f.write_char('[')?;
 
         let ipv4_length = self.ipv4.len();

--- a/src/utils/v4/ipv4_cidr_combiner.rs
+++ b/src/utils/v4/ipv4_cidr_combiner.rs
@@ -163,7 +163,7 @@ impl Ipv4CidrCombiner {
 
 impl Display for Ipv4CidrCombiner {
     #[inline]
-    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
         f.write_char('[')?;
 
         let length = self.cidr_array.len();

--- a/src/utils/v6/ipv6_cidr_combiner.rs
+++ b/src/utils/v6/ipv6_cidr_combiner.rs
@@ -170,7 +170,7 @@ impl Ipv6CidrCombiner {
 
 impl Display for Ipv6CidrCombiner {
     #[inline]
-    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
         f.write_char('[')?;
 
         let length = self.cidr_array.len();


### PR DESCRIPTION
Improves docs on a large portion of methods on `IpCidr`, `Ipv4Cidr`, and `Ipv6Cidr`. Tries to adhere to standard rustdoc grammar and formatting guidelines including using imperative mood for first line of function docs.

Also includes some trivial code quality improvements. No changes to public API have been made.