### PR TITLE
feat: remove unsafe fn from construction of combiners

### DIFF
--- a/src/utils/ip_cidr_combiner.rs
+++ b/src/utils/ip_cidr_combiner.rs
@@ -34,9 +34,21 @@ impl IpCidrCombiner {
         }
     }
 
-    #[allow(clippy::missing_safety_doc)]
+    /// Constructs a new `IpCidrCombiner` from lists of potentially-overlapping IP ranges.
     #[inline]
-    pub unsafe fn from_cidr_vec_unchecked(
+    pub fn from_cidr_vec(
+        ipv4_cidr_vec: Vec<Ipv4Cidr>,
+        ipv6_cidr_vec: Vec<Ipv6Cidr>,
+    ) -> IpCidrCombiner {
+        IpCidrCombiner {
+            ipv4: Ipv4CidrCombiner::from_ipv4_cidr_vec(ipv4_cidr_vec),
+            ipv6: Ipv6CidrCombiner::from_ipv6_cidr_vec(ipv6_cidr_vec),
+        }
+    }
+
+    /// Constructs a new `IpCidrCombiner` from lists of non-overlapping IP ranges.
+    #[inline]
+    pub fn from_cidr_vec_unchecked(
         ipv4_cidr_vec: Vec<Ipv4Cidr>,
         ipv6_cidr_vec: Vec<Ipv6Cidr>,
     ) -> IpCidrCombiner {

--- a/src/utils/ip_cidr_separator.rs
+++ b/src/utils/ip_cidr_separator.rs
@@ -13,7 +13,7 @@ impl IpCidrSeparator {
         match cidr {
             IpCidr::V4(cidr) => Ipv4CidrSeparator::divide_by(cidr, n).map(|v| {
                 v.into_iter()
-                    .map(|combiner| unsafe {
+                    .map(|combiner| {
                         IpCidrCombiner::from_cidr_vec_unchecked(
                             combiner.into_ipv4_cidr_vec(),
                             vec![],
@@ -23,7 +23,7 @@ impl IpCidrSeparator {
             }),
             IpCidr::V6(cidr) => Ipv6CidrSeparator::divide_by(cidr, n).map(|v| {
                 v.into_iter()
-                    .map(|combiner| unsafe {
+                    .map(|combiner| {
                         IpCidrCombiner::from_cidr_vec_unchecked(
                             vec![],
                             combiner.into_ipv6_cidr_vec(),

--- a/src/utils/v4/ipv4_cidr_combiner.rs
+++ b/src/utils/v4/ipv4_cidr_combiner.rs
@@ -28,9 +28,19 @@ impl Ipv4CidrCombiner {
         }
     }
 
-    #[allow(clippy::missing_safety_doc)]
+    /// Constructs a new `Ipv4CidrCombiner` from a list of potentially-overlapping IPv4 ranges.
     #[inline]
-    pub unsafe fn from_ipv4_cidr_vec_unchecked(cidr_vec: Vec<Ipv4Cidr>) -> Ipv4CidrCombiner {
+    pub fn from_ipv4_cidr_vec(cidr_vec: Vec<Ipv4Cidr>) -> Self {
+        let combiner = Self::with_capacity(cidr_vec.len());
+        cidr_vec.into_iter().fold(combiner, |mut combiner, cidr| {
+            combiner.push(cidr);
+            combiner
+        })
+    }
+
+    /// Constructs a new `Ipv4CidrCombiner` from a list of non-overlapping IPv4 ranges.
+    #[inline]
+    pub fn from_ipv4_cidr_vec_unchecked(cidr_vec: Vec<Ipv4Cidr>) -> Ipv4CidrCombiner {
         Ipv4CidrCombiner {
             cidr_array: cidr_vec
         }

--- a/src/utils/v6/ipv6_cidr_combiner.rs
+++ b/src/utils/v6/ipv6_cidr_combiner.rs
@@ -33,9 +33,23 @@ impl Ipv6CidrCombiner {
         }
     }
 
-    #[allow(clippy::missing_safety_doc)]
+    /// Constructs a new `Ipv4CidrCombiner` from a list of potentially-overlapping IPv4 ranges.
     #[inline]
-    pub unsafe fn from_ipv6_cidr_vec_unchecked(cidr_vec: Vec<Ipv6Cidr>) -> Ipv6CidrCombiner {
+    pub fn from_ipv6_cidr_vec(cidr_vec: Vec<Ipv6Cidr>) -> Self {
+        let combiner = Self::with_capacity(cidr_vec.len());
+        cidr_vec.into_iter().fold(combiner, |mut combiner, cidr| {
+            combiner.push(cidr);
+            combiner
+        })
+    }
+
+    /// Constructs a new `Ipv6CidrCombiner` from a list of non-overlapping IPv6 ranges.
+    ///
+    /// # Warning
+    ///
+    /// If `cidr_vec` contains any overlapping ranges, TODO
+    #[inline]
+    pub fn from_ipv6_cidr_vec_unchecked(cidr_vec: Vec<Ipv6Cidr>) -> Ipv6CidrCombiner {
         Ipv6CidrCombiner {
             cidr_array: cidr_vec
         }


### PR DESCRIPTION
## Motivation

`IpCidrCombiner` is not `unsafe`, in that contains no unsafe blocks or calls to other unsafe functions. Upholding logic requirements with `unsafe` is considered a misuse.

It's a shame that downstream `#[forbid(unsafe)]` crates can't use these constructors.

## Proposal

Remove the `unsafe` declarations for these `_unchecked` functions and detail in the documentation what the logic requirements are for the arguments. (I haven't been able to figure out exactly what these requirements are from reading `push` since there's no comments explaining what's going on.)

Also introduce constructors that use `push` internally for cases where the caller cannot guarantee the logic requirements.

Interested on your thoughts on this.